### PR TITLE
adds release title prefix in grenrc file

### DIFF
--- a/release-notes/.grenrc.default.js
+++ b/release-notes/.grenrc.default.js
@@ -1,6 +1,6 @@
 module.exports = {
     "dataSource": "prs",
-    "prefix": "",
+    "prefix": "Release v",
     "onlyMilestones": false,
     "ignoreIssuesWith": ["no-release", "wontfix", "question"],
     "ignoreTagsWith": ["-rc", "-alpha", "-beta", "test", "current"],


### PR DESCRIPTION
## Description
adds release title prefix `"prefix": "Release v"` in grenrc file as this is deleting our default prefix after run as observed in pinot and gateway service workflow runs. 

### Testing
used local .genrc to update notes in gateway service. 

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

