### PR TITLE
fix: adds condition to handle no label situation in release notes action

### DIFF
--- a/release-notes/.grenrc.default.js
+++ b/release-notes/.grenrc.default.js
@@ -1,44 +1,47 @@
 module.exports = {
-    "dataSource": "prs",
-    "prefix": "",
-    "onlyMilestones": false,
-    "ignoreIssuesWith": ["no-release", "wontfix", "question"],
-    "ignoreTagsWith": ["-rc", "-alpha", "-beta", "test", "current"],
-    "ignoreLabels": ["closed", "automation", "enhancement", "bug", "fix",
-      "internal", "feature", "feat", "docs", "chore", "refactor", "ci",
-      "perf", "test", "tests", "style", "linux"],
-    "groupBy": {
-        "Enhancements": ["enhancement", "internal", "feature", "feat"],
-        "Bug Fixes": ["bug", "fix"],
-        "Documentation": ["docs", "question"],
-        "Minor Fixes": ["chore", "refactor", "perf", "test", "style"],
-        "Config": ["config", "helm"],
-        "CI": ["ci"]
-    },
-    "template": {
-        commit: ({ message, url, author, name }) => `- [${message}](${url}) - ${author ? `@${author}` : name}`,
-        issue: "- {{labels}} {{name}} [{{text}}]({{url}})",
-        label: "[**{{label}}**]",
-        noLabel: "closed",
-        changelogTitle: "# Changelog\n\n",
-        release: "## {{release}} ({{date}})\n{{body}}",
-        releaseSeparator: "\n---\n\n",
-        group: function (placeholders) {
-          var icon = "🙈"
-          if(placeholders.heading == 'Enhancements'){
-            icon = "🚀"
-          } else if(placeholders.heading == 'Bug Fixes'){
-            icon = "🐛"
-          } else if(placeholders.heading == 'Documentation'){
-            icon = "📚"
-          } else if(placeholders.heading == 'Minor Fixes'){
-            icon = "❗"
-          } else if(placeholders.heading == 'Config'){
-            icon = "⚙️"
-          } else if(placeholders.heading == 'CI'){
-            icon = "⚡"
-          }
-          return '\n#### ' + icon + ' ' + placeholders.heading + '\n';
+  "dataSource": "prs",
+  "prefix": "Release v",
+  "onlyMilestones": false,
+  "ignoreIssuesWith": ["no-release", "wontfix", "question"],
+  "ignoreTagsWith": ["-rc", "-alpha", "-beta", "test", "current"],
+  "ignoreLabels": ["closed", "automation", "enhancement", "bug", "fix",
+    "internal", "feature", "feat", "docs", "chore", "refactor", "ci",
+    "perf", "test", "tests", "style", "linux"],
+  "groupBy": {
+      "Enhancements": ["enhancement", "internal", "feature", "feat"],
+      "Bug Fixes": ["bug", "fix"],
+      "Documentation": ["docs", "question"],
+      "Minor Fixes": ["chore", "refactor", "perf", "test", "style"],
+      "Config": ["config", "helm"],
+      "CI": ["ci"],
+      "Changes": []
+  },
+  "template": {
+      commit: ({ message, url, author, name }) => `- [${message}](${url}) - ${author ? `@${author}` : name}`,
+      issue: "- {{labels}} {{name}} [{{text}}]({{url}})",
+      label: "[**{{label}}**]",
+      noLabel: "closed",
+      changelogTitle: "# Changelog\n\n",
+      release: "## {{release}} ({{date}})\n{{body}}",
+      releaseSeparator: "\n---\n\n",
+      group: function (placeholders) {
+        var icon = "🙈"
+        if(placeholders.heading == 'Enhancements'){
+          icon = "🚀"
+        } else if(placeholders.heading == 'Bug Fixes'){
+          icon = "🐛"
+        } else if(placeholders.heading == 'Documentation'){
+          icon = "📚"
+        } else if(placeholders.heading == 'Minor Fixes'){
+          icon = "❗"
+        } else if(placeholders.heading == 'Config'){
+          icon = "⚙️"
+        } else if(placeholders.heading == 'CI'){
+          icon = "⚡"
+        } else if(placeholders.heading == 'Changes'){
+          icon = "😇"
         }
-    }
+        return '\n#### ' + icon + ' ' + placeholders.heading + '\n';
+      }
+  }
 }


### PR DESCRIPTION
## Description
adds bucket which will contain all changes without labels in grenrc. 


### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

