### PR TITLE
fix: update grenrc to use closed as label

### DIFF
--- a/release-notes/.grenrc.default.js
+++ b/release-notes/.grenrc.default.js
@@ -14,7 +14,7 @@ module.exports = {
       "Minor Fixes": ["chore", "refactor", "perf", "test", "style"],
       "Config": ["config", "helm"],
       "CI": ["ci"],
-      "Changes": []
+      "Changes": ["closed"]
   },
   "template": {
       commit: ({ message, url, author, name }) => `- [${message}](${url}) - ${author ? `@${author}` : name}`,


### PR DESCRIPTION
## Description
- Update with release notes for PRs with no labels under empty buckets was inconsistent. 
- Using closed label so all closed/merged PRs will be part of that bucket.


### Testing
Updated notes for tags here: https://github.com/hypertrace/entity-service/releases

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation
- https://github.com/github-tools/github-release-notes/blob/1ae865da45a6b9040e061620e8e57e09ae7771f2/docs/examples.md#group-by 
