### PR TITLE
feat: checksum more files

### DIFF
--- a/checksum/action.yml
+++ b/checksum/action.yml
@@ -3,5 +3,5 @@ description: 'Generates checksum for caching'
 runs:
   using: "composite"
   steps: 
-    - run: find . -type f -name "*.gradle*" -o -name "gradle-wrapper*" | xargs shasum | sort > checksum.txt && cat checksum.txt
+    - run: find . -type f -name "*.gradle*" -o -name "gradle-wrapper*" -o -path "./gradle/*"| xargs shasum | sort > checksum.txt && cat checksum.txt
       shell: bash


### PR DESCRIPTION
## Description
Adding more files to the checksum. This is particularly useful when using gradle version catalogs, include a file at `gradle/libs.versions.toml`


### Testing
Ran updated bash script and visually verified results