### PR TITLE
feat: update gradle to use gradle supported action

### DIFF
--- a/gradle/action.yml
+++ b/gradle/action.yml
@@ -10,9 +10,9 @@ runs:
     - uses: gradle/gradle-build-action@v2
       with:
         arguments: |
-          ${{ inputs.args }}
           --info
           --max-workers=2
           -Dorg.gradle.jvmargs=-Xmx4g
           -Dorg.gradle.console=plain 
           --continue
+          ${{ inputs.args }}

--- a/gradle/action.yml
+++ b/gradle/action.yml
@@ -7,6 +7,12 @@ inputs:
 runs:
   using: "composite"
   steps: 
-    - run: |
-          ./gradlew ${{ inputs.args }} --info --max-workers=2 -Dorg.gradle.jvmargs=-Xmx2g -Dorg.gradle.console=plain --continue
-      shell: sh
+    - uses: gradle/gradle-build-action@v2
+      with:
+        arguments: |
+          ${{ inputs.args }}
+          --info
+          --max-workers=2
+          -Dorg.gradle.jvmargs=-Xmx4g
+          -Dorg.gradle.console=plain 
+          --continue


### PR DESCRIPTION
## Description
2 changes here.

1. increased the heap limit on gradle action from 2GB to 4GB, since the runners have 7GB available this should help builds run faster by default.
2. Use https://github.com/gradle/gradle-build-action by default. This is a much more robust action than our own, and we wrap it only to include common build args like logging. This now caches by default, so those steps can (and should) be removed from all workflows.