### PR TITLE
refactor: allow gradle to be invoked without argument

### DIFF
--- a/gradle/action.yml
+++ b/gradle/action.yml
@@ -2,8 +2,8 @@ name: 'Gradle command action'
 description: 'standardizes the CLI flags for gradle'
 inputs:
   args:
-    description: 'command you want to execute'
-    required: true
+    description: 'command you want to execute. If omitted, gradle is set up without executing any tasks'
+    required: false
 runs:
   using: "composite"
   steps: 


### PR DESCRIPTION
## Description
Gradle runs the help command by default, if no task is listed. By removing the requirement for args, we expose the same functionality. This allows the bootstrapping of gradle and its cache to happen by calling without arguments, making it easy to use in a script, for example.