### PR TITLE
ci: change default trivy output to log which works for all

### DIFF
--- a/trivy-image-scan/action.yml
+++ b/trivy-image-scan/action.yml
@@ -30,7 +30,7 @@ inputs:
   output-mode:
     description: 'Upload to github security via sarif format (github), or log pretty print output (log)'
     required: true
-    default: 'github'
+    default: 'log'
 runs:
   using: "composite"
   steps:
@@ -59,7 +59,6 @@ runs:
       shell: bash
       run: |
         echo "FORMAT=table" >> $GITHUB_ENV
-        echo "OUTPUT=''" >> $GITHUB_ENV
 
     - name: Default ignore file if not exist
       if: ${{ inputs.trivyignores == '.trivyignore' }}  # If a non-default ignore is passed, then we can assume it exists


### PR DESCRIPTION
## Description

Log output works on all repo, github only for repos with security enabled. Switching default behavior to case that always works. Also fixed issue with unset output. 
