### PR TITLE
Add scanner flag

### DIFF
--- a/trivy-fs-scan/action.yaml
+++ b/trivy-fs-scan/action.yaml
@@ -12,6 +12,10 @@ inputs:
     description: 'comma-separated list of vulnerability types (os,library)'
     required: true
     default: 'library'
+  scanners:
+    description: 'comma-separated list of what security issues to detect (vuln,secret,config)'
+    required: true
+    default: 'vuln'
   severity:
     description: 'severities of vulnerabilities to be displayed'
     required: true
@@ -69,6 +73,7 @@ runs:
         scan-type: 'fs'
         scan-ref: ${{ inputs.scan-ref }}
         vuln-type: ${{ inputs.vuln-type }}
+        scanners: ${{ inputs.scanners }}
         trivyignores: ${{ inputs.trivyignores }}
         format: ${{ steps.output.outputs.TRIVY_FORMAT }}
         output: ${{ steps.output.outputs.TRIVY_OUTPUT }}

--- a/trivy-fs-scan/action.yaml
+++ b/trivy-fs-scan/action.yaml
@@ -12,10 +12,6 @@ inputs:
     description: 'comma-separated list of vulnerability types (os,library)'
     required: true
     default: 'library'
-  scanners:
-    description: 'comma-separated list of what security issues to detect (vuln,secret,config)'
-    required: true
-    default: 'vuln'
   severity:
     description: 'severities of vulnerabilities to be displayed'
     required: true
@@ -73,7 +69,7 @@ runs:
         scan-type: 'fs'
         scan-ref: ${{ inputs.scan-ref }}
         vuln-type: ${{ inputs.vuln-type }}
-        scanners: ${{ inputs.scanners }}
+        scanners: 'vuln'
         trivyignores: ${{ inputs.trivyignores }}
         format: ${{ steps.output.outputs.TRIVY_FORMAT }}
         output: ${{ steps.output.outputs.TRIVY_OUTPUT }}


### PR DESCRIPTION
## Description
Please include a summary of the change, motivation and context.

For trivy fs scan, by default secret scanning is enabled. We already have secret scanning and handled. The problem here is trivy does not have false positive handling for secret scanning except you can skip scanning the directory. Since we already have secret scanning, i dont want to introduce another secret scans which does not have false positive handling.

This pr adds scanner flag where gh can opt for vulnerability, config, secret scans

### Testing
This has been tested in a local github repo and it works well. 

