### PR TITLE
ci: add refresh dependencies to more quickly propagate changes

### DIFF
--- a/raise-lock-pr/action.yaml
+++ b/raise-lock-pr/action.yaml
@@ -10,7 +10,7 @@ runs:
     - name: Update lockfiles
       uses: hypertrace/github-actions/gradle@main
       with:
-        args: resolveAndLockAll --write-locks
+        args: resolveAndLockAll --write-locks --refresh-dependencies
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v5
       with:

--- a/raise-lock-pr/action.yaml
+++ b/raise-lock-pr/action.yaml
@@ -15,7 +15,7 @@ runs:
       with:
         args: resolveAndLockAll --write-locks --refresh-dependencies
     - name: Remove settings lock if needed
-      if: inputs.lock-settings == 'true'
+      if: inputs.lock-settings != 'true'
       shell: bash
       run: rm settings-gradle.lockfile
     - name: Create Pull Request

--- a/raise-lock-pr/action.yaml
+++ b/raise-lock-pr/action.yaml
@@ -4,9 +4,9 @@ inputs:
   token:
     description: 'Github auth token with permissions to raise a PR'
     required: true
-  post-process:
+  lock-settings:
     description: 'shell command to run after updating lock files. Can be used to cleanup locks'
-    default: 'git status'
+    default: 'false'
 runs:
   using: composite
   steps:
@@ -14,9 +14,10 @@ runs:
       uses: hypertrace/github-actions/gradle@main
       with:
         args: resolveAndLockAll --write-locks --refresh-dependencies
-    - name: Post process
+    - name: Remove settings lock if needed
+      if: inputs.lock-settings == 'true'
       shell: bash
-      run: ${{ inputs.args }}
+      run: rm settings-gradle.lockfile
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v5
       with:

--- a/raise-lock-pr/action.yaml
+++ b/raise-lock-pr/action.yaml
@@ -4,6 +4,9 @@ inputs:
   token:
     description: 'Github auth token with permissions to raise a PR'
     required: true
+  post-process:
+    description: 'shell command to run after updating lock files. Can be used to cleanup locks'
+    default: 'git status'
 runs:
   using: composite
   steps:
@@ -11,6 +14,9 @@ runs:
       uses: hypertrace/github-actions/gradle@main
       with:
         args: resolveAndLockAll --write-locks --refresh-dependencies
+    - name: Post process
+      shell: bash
+      run: ${{ inputs.args }}
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v5
       with:

--- a/raise-lock-pr/action.yaml
+++ b/raise-lock-pr/action.yaml
@@ -17,7 +17,7 @@ runs:
     - name: Remove settings lock if needed
       if: inputs.lock-settings != 'true'
       shell: bash
-      run: rm settings-gradle.lockfile
+      run: rm settings-gradle.lockfile || true
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v5
       with:


### PR DESCRIPTION
## Description

`--refresh-dependencies` helps this action pull changes more quickly. Because we typically cache gradle, that'll use the default behavior of 24h between changes ( https://docs.gradle.org/current/userguide/dynamic_versions.html#sec:controlling-dynamic-version-caching )