### PR TITLE
ci: fail sarif build only if requested severity thresholds are reached

### DIFF
--- a/trivy-image-scan/action.yml
+++ b/trivy-image-scan/action.yml
@@ -90,6 +90,7 @@ runs:
         severity: ${{ inputs.severity }}
         ignore-unfixed: ${{ inputs.ignore-unfixed }}
         timeout: ${{ inputs.timeout }}
+        limit-severities-for-sarif: true
         exit-code: '1'
 
     - name: Upload Trivy scan results to GitHub Security tab


### PR DESCRIPTION
## Description

Apparent breaking change in trivy. I see this mentioned in a bug filed against the release yesterday, so we're not the only ones experience the sudden change, but the actual change causing this appears rather old, so not exactly sure why it just started happening. By specifying this flag though, seems to restore the expected behavior.
https://github.com/aquasecurity/trivy-action/blob/2b6a709cf9c4025c5438138008beaddbb02086f0/entrypoint.sh#L176-L178