### PR TITLE
chore: updating helm template for postgresql

### DIFF
--- a/validate-charts/values.tpl
+++ b/validate-charts/values.tpl
@@ -111,10 +111,10 @@ redis:
 
 postgresql:
   primary:
-    commonPodAnnotations:
+    podAnnotations:
       traceable.ai/test: "1234567890"
 
-    commonPodLabels:
+    podLabels:
       applicationid: ABCD1234
 
     containerSecurityContext:


### PR DESCRIPTION

The Bitnami PostgreSQL image templates do not use commonPodAnnotations and commonPodLabels.
Instead, the templates use podLabels and podAnnotations, as seen here: [values.yaml#L545](https://github.com/bitnami/charts/blob/main/bitnami/postgresql/values.yaml#L545).
Updating the validation template accordingly.


