### PR TITLE
update codeql-action action version

### DIFF
--- a/trivy-image-scan/action.yml
+++ b/trivy-image-scan/action.yml
@@ -119,13 +119,13 @@ runs:
         TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db
 
     - name: Upload Trivy scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@v2
+      uses: github/codeql-action/upload-sarif@v3
       if: (success() || failure()) && inputs.output-mode == 'github' && steps.output.outputs.TRIVY_OUTPUT != '' && inputs.category == ''
       with:
         sarif_file: ${{ steps.output.outputs.TRIVY_OUTPUT }}
 
     - name: Upload Trivy scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@v2
+      uses: github/codeql-action/upload-sarif@v3
       if: (success() || failure()) && inputs.output-mode == 'github' && steps.output.outputs.TRIVY_OUTPUT != '' && inputs.category != ''
       with:
         sarif_file: ${{ steps.output.outputs.TRIVY_OUTPUT }}


### PR DESCRIPTION
```
Error: CodeQL Action major versions v1 and v2 have been deprecated. Please update all occurrences of the CodeQL Action in your workflow files to v3. For more information, see https://github.blog/changelog/2025-01-10-code-scanning-codeql-action-v2-is-now-deprecated/
```