### PR TITLE
ci: update gradle action to v4 to restore caching

### DIFF
--- a/.github/workflows/validate-workflows.yml
+++ b/.github/workflows/validate-workflows.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   validate:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     
     steps:
       - name: Checkout local repository

--- a/gradle/action.yml
+++ b/gradle/action.yml
@@ -12,12 +12,19 @@ inputs:
     description: 'max heap to allocate to gradle'
     required: true
     default: '6g'
+  gradle-executable:
+    description: 'gradle wrapper executable'
+    required: true
+    default: './gradlew'
 runs:
   using: "composite"
-  steps: 
-    - uses: gradle/gradle-build-action@v2
-      with:
-        arguments: |
+  steps:
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v4
+    - name: Execute Gradle Command
+      shell: bash
+      run: |
+          ${{ inputs.gradle-executable }}
           --info
           --max-workers=${{ inputs.max-workers }}
           -Dorg.gradle.jvmargs=-Xmx${{ inputs.max-heap }}


### PR DESCRIPTION
Updating gradle action based on https://github.com/gradle/actions/blob/v4.3.1/docs/deprecation-upgrade-guide.md