### PR TITLE
Pin trivy

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Each line is a file pattern followed by one or more owners.
 
 # global
-* @jbahire @aaron-steinfeld @kotharironak @ravisingal @tim-mwangi
+* @aaron-steinfeld @ravisingal @tim-mwangi
 

--- a/trivy-fs-scan/action.yaml
+++ b/trivy-fs-scan/action.yaml
@@ -73,7 +73,7 @@ runs:
         touch .trivyignore
 
     - name: Run Trivy vulnerability scanner
-      uses: aquasecurity/trivy-action@master
+      uses: aquasecurity/trivy-action@9ea583eb67910444b1f64abf338bd2e105a0a93d
       with:
         scan-type: 'fs'
         scan-ref: ${{ inputs.scan-ref }}

--- a/trivy-image-scan/action.yml
+++ b/trivy-image-scan/action.yml
@@ -86,7 +86,7 @@ runs:
         cat $GITHUB_ACTION_PATH/.trivyignore >> .trivyignore
 
     - name: Run Trivy vulnerability scanner
-      uses: aquasecurity/trivy-action@master
+      uses: aquasecurity/trivy-action@9ea583eb67910444b1f64abf338bd2e105a0a93d
       with:
         trivyignores: ${{ inputs.trivyignores }}
         image-ref: ${{ inputs.image }}:${{ steps.tag.outputs.TRIVY_IMAGE_TAG }}
@@ -104,7 +104,7 @@ runs:
 
     - name: Rerun Trivy vulnerability scanner with logging
       if: failure() && inputs.output-mode != 'log'
-      uses: aquasecurity/trivy-action@master
+      uses: aquasecurity/trivy-action@9ea583eb67910444b1f64abf338bd2e105a0a93d
       with:
         trivyignores: ${{ inputs.trivyignores }}
         image-ref: ${{ inputs.image }}:${{ steps.tag.outputs.TRIVY_IMAGE_TAG }}


### PR DESCRIPTION
## Description

Pin trivy - should be done regardless for security reasons, but this is specifically to avoid a [breaking change](https://github.com/aquasecurity/setup-trivy/pull/22) in the trivy repo pinning to a checkout action that requires node 24.