### PR TITLE
ci: fix sha

### DIFF
--- a/trivy-fs-scan/action.yaml
+++ b/trivy-fs-scan/action.yaml
@@ -73,7 +73,7 @@ runs:
         touch .trivyignore
 
     - name: Run Trivy vulnerability scanner
-      uses: aquasecurity/trivy-action@9ea583eb67910444b1f64abf338bd2e105a0a93d
+      uses: aquasecurity/trivy-action@dc5a429b52fcf669ce959baa2c2dd26090d2a6c4
       with:
         scan-type: 'fs'
         scan-ref: ${{ inputs.scan-ref }}

--- a/trivy-image-scan/action.yml
+++ b/trivy-image-scan/action.yml
@@ -86,7 +86,7 @@ runs:
         cat $GITHUB_ACTION_PATH/.trivyignore >> .trivyignore
 
     - name: Run Trivy vulnerability scanner
-      uses: aquasecurity/trivy-action@9ea583eb67910444b1f64abf338bd2e105a0a93d
+      uses: aquasecurity/trivy-action@dc5a429b52fcf669ce959baa2c2dd26090d2a6c4
       with:
         trivyignores: ${{ inputs.trivyignores }}
         image-ref: ${{ inputs.image }}:${{ steps.tag.outputs.TRIVY_IMAGE_TAG }}
@@ -104,7 +104,7 @@ runs:
 
     - name: Rerun Trivy vulnerability scanner with logging
       if: failure() && inputs.output-mode != 'log'
-      uses: aquasecurity/trivy-action@9ea583eb67910444b1f64abf338bd2e105a0a93d
+      uses: aquasecurity/trivy-action@dc5a429b52fcf669ce959baa2c2dd26090d2a6c4
       with:
         trivyignores: ${{ inputs.trivyignores }}
         image-ref: ${{ inputs.image }}:${{ steps.tag.outputs.TRIVY_IMAGE_TAG }}


### PR DESCRIPTION
## Description

Accidentally used SHA from https://github.com/aquasecurity/setup-trivy (which is where the failure is) instead of https://github.com/aquasecurity/trivy-action (which is the one we access)