### PR TITLE
chore: disabling central analyzer until stable

### DIFF
--- a/dependency-check/action.yml
+++ b/dependency-check/action.yml
@@ -33,13 +33,13 @@ runs:
       if: inputs.nvd-api-key == ''
       uses: hypertrace/github-actions/gradle@main
       with:
-        args: dependencyCheckAggregate ${{steps.suppressions.outputs.args}} -Danalyzer.ossindex.enabled=false
+        args: dependencyCheckAggregate ${{steps.suppressions.outputs.args}} -Danalyzer.ossindex.enabled=false -Danalyzer.central.enabled=false
 
     - name: Dependency Check
       if: inputs.nvd-api-key != ''
       uses: hypertrace/github-actions/gradle@main
       with:
-        args: dependencyCheckAggregate ${{steps.suppressions.outputs.args}} -Dnvd.api.key=${{ inputs.nvd-api-key }} -Danalyzer.ossindex.enabled=false
+        args: dependencyCheckAggregate ${{steps.suppressions.outputs.args}} -Dnvd.api.key=${{ inputs.nvd-api-key }} -Danalyzer.ossindex.enabled=false -Danalyzer.central.enabled=false
 
     - name: Upload dependency check report
       if: always()


### PR DESCRIPTION
Maven search is down more often than not recently preventing all checks from running. will revisit enabling it once more stable.