### PR TITLE
ci: update raise lock to use latest create pr

### DIFF
--- a/raise-lock-pr/action.yaml
+++ b/raise-lock-pr/action.yaml
@@ -22,7 +22,7 @@ runs:
       shell: bash
       run: rm settings-gradle.lockfile || true
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v5
+      uses: peter-evans/create-pull-request@v8
       with:
         title: ${{ inputs.pr-title }}
         body: |


### PR DESCRIPTION
Old version was incompatible with checkout v6 breaking upstream repos: https://github.com/peter-evans/create-pull-request/releases/tag/v7.0.9