### PR TITLE
ci: fix SHA to update trivy to 0.69.3

### DIFF
--- a/trivy-image-scan/action.yml
+++ b/trivy-image-scan/action.yml
@@ -86,7 +86,7 @@ runs:
         cat $GITHUB_ACTION_PATH/.trivyignore >> .trivyignore
 
     - name: Run Trivy vulnerability scanner
-      uses: aquasecurity/trivy-action@dc5a429b52fcf669ce959baa2c2dd26090d2a6c4
+      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
       with:
         trivyignores: ${{ inputs.trivyignores }}
         image-ref: ${{ inputs.image }}:${{ steps.tag.outputs.TRIVY_IMAGE_TAG }}
@@ -104,7 +104,7 @@ runs:
 
     - name: Rerun Trivy vulnerability scanner with logging
       if: failure() && inputs.output-mode != 'log'
-      uses: aquasecurity/trivy-action@dc5a429b52fcf669ce959baa2c2dd26090d2a6c4
+      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
       with:
         trivyignores: ${{ inputs.trivyignores }}
         image-ref: ${{ inputs.image }}:${{ steps.tag.outputs.TRIVY_IMAGE_TAG }}


### PR DESCRIPTION
## Description
Due to a security incident, all trivy releases from v0.27.0 to v0.69.1 were permanently deleted. Refer https://github.com/goharbor/harbor/issues/22895 for more details.
The SHA pointed to [this commit of trivy-action](https://github.com/aquasecurity/trivy-action/tree/dc5a429b52fcf669ce959baa2c2dd26090d2a6c4/) which uses 0.64.1 version of trivy which also got deleted. Due to this, the trivy vulnerability scanner step in build action is failing in hypertrace repos (e.g. https://github.com/hypertrace/config-service/actions/runs/23290175030/job/67723807940?pr=340).

Fix is to update the SHA to point to the [latest commit](https://github.com/aquasecurity/trivy-action/commit/57a97c7e7821a5776cebc9bb87c984fa69cba8f1) which uses v0.69.3 of trivy.