### PR TITLE
Add suppression for CVE-2026-42154 in global suppressions

### DIFF
--- a/dependency-check/global-suppressions.xml
+++ b/dependency-check/global-suppressions.xml
@@ -175,4 +175,15 @@
     </packageUrl>
     <cve>CVE-2026-5795</cve>
   </suppress>
+  <!-- False positive: CVE-2026-42154 is a DoS in the Prometheus server's remote read endpoint,
+       not the Java simpleclient metrics library (io.prometheus:simpleclient*) -->
+  <suppress>
+    <notes><![CDATA[
+      CVE-2026-42154 affects the Prometheus server (Go binary), not the Java client library.
+      The OWASP dependency-check incorrectly matches io.prometheus:simpleclient* against
+      cpe:2.3:a:prometheus:prometheus due to the shared "prometheus" name.
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/io\.prometheus/simpleclient.*@.*$</packageUrl>
+    <cve>CVE-2026-42154</cve>
+  </suppress>
 </suppressions>


### PR DESCRIPTION
Added suppression for CVE-2026-42154 to clarify that it affects the Prometheus server, not the Java client library.