### PR TITLE
NO-TICKET: Bump default Gradle max-workers from 2 to 4 for update locks

### DIFF
--- a/raise-lock-pr/action.yaml
+++ b/raise-lock-pr/action.yaml
@@ -17,6 +17,7 @@ runs:
       uses: hypertrace/github-actions/gradle@main
       with:
         args: resolveAndLockAll --write-locks --refresh-dependencies
+      max-workers: '4'
     - name: Remove settings lock if needed
       if: inputs.lock-settings != 'true'
       shell: bash

--- a/raise-lock-pr/action.yaml
+++ b/raise-lock-pr/action.yaml
@@ -17,7 +17,7 @@ runs:
       uses: hypertrace/github-actions/gradle@main
       with:
         args: resolveAndLockAll --write-locks --refresh-dependencies
-      max-workers: '4'
+        max-workers: '4'
     - name: Remove settings lock if needed
       if: inputs.lock-settings != 'true'
       shell: bash


### PR DESCRIPTION
## Description
Increases default parallelism for all Gradle invocations (builds, lock updates, tests) across all consuming repos. This helps speed up lock resolution and dependency-heavy tasks without requiring per-repo changes.

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Will check if lock PRs run faster

### Checklist:
- [X] My changes generate no new warnings

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
